### PR TITLE
Fix crash when there is a previous source map

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ module.exports = PostCSSCompiler = (function() {
 			}
 		};
 		if (params.map) {
-			opts.map.prev = params.map;
+			opts.map.prev = params.map.toJSON();
 		}
 
 		postcss(this.processors).process(params.data, opts)


### PR DESCRIPTION
Postcss is supposed to accept a mozilla/source-map SourceMapGenerator as a
previous source map, but the instanceof check postcss uses fails because
postcss and brunch use different versions of mozilla/source-map.

This commit works around the problem by converting the SourceMapGenerator
instance to a regular JavaScript object before passing it to postcss.

See https://github.com/iamvdo/postcss-brunch/pull/6#issuecomment-106387939 and
the following comments.
