### PR TITLE
Remove map option sourcesContent

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,8 +23,7 @@ module.exports = PostCSSCompiler = (function() {
 			to:   params.path,
 			map:  {
 				inline: false,
-				annotation: false,
-				sourcesContent: false
+				annotation: false
 			}
 		};
 		if (params.map) {


### PR DESCRIPTION
When the map option sourcesContent is set to false, I have in the source
map html code. But when sourcesContent is true, source map is ok.
sourcesContent by default is true, so I just removed it.
