### PR TITLE
Feature/better warnings and errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,10 +29,14 @@ class PostCSSCompiler {
 
 		return postcss(this.processors).process(file.data, opts)
 			.then(result => {
-				result.warnings().forEach(warn => {
-					logger.warn(warn);
-				});
-
+				if (result.warnings().length > 0) {
+					process.stderr.write("[postcss-brunch] warnings:\n");
+					result.warnings().forEach(warn => {
+						const line = warn.line ? `line ${this.pad(warn.line, 4)}` : ''
+						const col = warn.col ? ` col ${this.pad(warn.col, 3)}` : ''
+						process.stderr.write(`\t[${warn.plugin}]:${warn.node ? ' ' + warn.node.toString() : ''}\t${line}${col}: ${warn.text}\n`);
+					});
+				}
 				return {
 					path,
 					data: result.css,
@@ -41,10 +45,14 @@ class PostCSSCompiler {
 			})
 			.catch(error => {
 				if (error.name === 'CssSyntaxError') {
-					throw error.message + error.showSourceCode();
+					process.stderr.write(`[postcss-brunch] CSS syntax error: \n\t${error.message} ${error.showSourceCode()}\n`);
+				} else {
+					throw error;
 				}
-				throw error;
 			});
+	}
+	pad(stringeable, length) {
+		return ' '.repeat(length-String(stringeable).length) + String(stringeable);
 	}
 }
 
@@ -55,4 +63,3 @@ Object.assign(PostCSSCompiler.prototype, {
 });
 
 module.exports = PostCSSCompiler;
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const postcss = require('postcss');
 const progeny = require('progeny');
-const logger = require('loggy');
 
 class PostCSSCompiler {
 	constructor(config) {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   },
   "dependencies": {
     "postcss": "^5.0.0",
-    "progeny": "^0.5.2",
-    "loggy": "~0.3.5"
+    "progeny": "^0.5.2"
   },
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
This improves the reporting of errors and warnings. 

Most importantly, CSS syntax errors will now actually be reported:

before:

```
#> brunch b
16 Aug 13:14:04 - error: undefined of web/static/css/sp.css failed. Unexpected identifier
```

now:

```
#> brunch b
[postcss-brunch] CSS syntax error:
    /[...]/web/static/css/sp.css:4:1: Unexpected }
font-family: 'Comic Sans'}
}
^
article {
16 Aug 12:51:49 - info: compiled 2 files into spa.js in 767 ms
```

Warnings are written to stderr as prescribed in the[ guidelines](https://github.com/postcss/postcss/blob/master/docs/guidelines/runner.md#3-output).  

They are reported in a table format:

before:

```
16 Aug 13:13:05 - warn: Warning {
  type: 'warning',
  text: 'Your formatting is strange.',
  line: 12,
  col: 34,
  word: 'xxx',
  index: 1,
  plugin: 'postcss-freestyle' }
16 Aug 13:13:05 - warn: Warning {
  type: 'warning',
  text: 'Call your mom!',
  word: '2016-07-05',
  index: 1,
  col: 1,
  line: 1,
  plugin: 'postcss-conscience' }
16 Aug 13:13:05 - warn: Warning {
  type: 'warning',
  text: 'Your Syntax is so 2016!',
  word: '{}',
  index: 1,
  col: 45,
  line: 42,
  plugin: 'postcss-postpostcss' }
16 Aug 13:13:05 - info: compiled 3 files into 2 files in 793 ms
```

now:

```
postcss-brunch] warnings:
    [postcss-freestyle]:    at line   12, col 34:   Your formatting is strange.
    [postcss-conscience]:   at line    1, col  1:   Call your mom!
    [postcss-postpostcss]:  at line   42, col 45:   Your Syntax is so 2016!
16 Aug 13:09:35 - info: compiled 3 files into 2 files in 777 ms
```

Loggy is no longer needed. If it is wanted for custom error reporting (i. e. with desktop notifications) it could be used as a formatter for [postcss-reporter](https://github.com/postcss/postcss-reporter)

```
reporter({
  formatter: function(input) {
    return loggy(input.source + ' produced ' + input.messages.length + ' messages');
  }
})
```
