### PR TITLE
Add css-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,55 @@ plugins: {
 
 You can add as many processors as you want. CSS will be parsed only once. See [PostCSS](https://github.com/ai/postcss) and each plugins docs.
 
+### CSS Modules
+
+You can use CSS Modules with postcss-brunch. To enable it, change your config to:
+
+```javascript
+module.exports = {
+  // ...
+  plugins: {
+    postcss: {
+      modules: true
+    }
+  }
+};
+```
+
+You can also pass options directly to
+[postcss-modules](https://github.com/css-modules/postcss-modules):
+
+```javascript
+module.exports = {
+  // ...
+  plugins: {
+    postcss: {
+      modules: {
+        generateScopedName: '[name]__[local]___[hash:base64:5]'
+      }
+    }
+  }
+};
+```
+
+Then, author your styles like you normally would:
+
+```css
+.title {
+  font-size: 32px;
+}
+```
+
+And reference CSS class names by requiring the specific style into your javascript:
+
+```javascript
+var style = require('./title.css');
+
+<h1 className={style.title}>Yo</h1>
+```
+
+Note: enabling `modules` does so for every stylesheet in your project, so it's all-or-nothing. Even the files you don't require will be transformed into CSS modules (aka will have obfuscated class names, like turn `.title` into `._title_fdphn_1`).
+
 ## License
 
 MIT

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "loggy": "~0.3.5",
     "postcss": "^5.0.0",
+    "postcss-modules": "^0.5.2",
     "progeny": "~0.9.0"
   },
   "license": "MIT",


### PR DESCRIPTION
This addresses https://github.com/brunch/css-brunch/issues/11

Don't merge this yet as it's appears to be working, but is emitting warnings like

```
21 Sep 10:48:31 - warn: node_modules/sanitize.css/sanitize.css compiled, but not written. Check your javascripts.joinTo config
21 Sep 10:48:31 - warn: app/styles/main.css compiled, but not written. Check your javascripts.joinTo config
```

If someone is able to test this and check that source-maps still work correctly as well, that would be great.
