### PR TITLE
Add support for running preprocessors before postcss

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class PostCSSCompiler {
 		this.modules = !!this.config.modules;
 	}
 
-	compile(file) {
+	optimize(file) {
 		const path = file.path;
 		const opts = {from: path, to: sysPath.basename(path), map: this.map};
 
@@ -93,7 +93,7 @@ class PostCSSCompiler {
 Object.assign(PostCSSCompiler.prototype, {
 	brunchPlugin: true,
 	type: 'stylesheet',
-	extension: 'css',
+	defaultEnv: '*',
 });
 
 module.exports = PostCSSCompiler;

--- a/test.js
+++ b/test.js
@@ -54,7 +54,7 @@ describe('Plugin', () => {
 
   it('compile', () => {
     const data = 'a{a:a}';
-    return plugin.compile({path: 'a.css', data}).then(file => {
+    return plugin.optimize({path: 'a.css', data}).then(file => {
       file.data.should.be.eql(data);
     });
   });
@@ -62,7 +62,7 @@ describe('Plugin', () => {
   it('compile with options', () => {
      const data = fs.readFileSync('fixtures/sample.css', 'utf-8');
      const expected = fs.readFileSync('fixtures/sample.out.css', 'utf-8');
-     return plugin.compile({path: 'a.css', data}).then(actual => {
+     return plugin.optimize({path: 'a.css', data}).then(actual => {
        actual.data.should.eql(expected);
      });
   });
@@ -76,7 +76,7 @@ describe('Plugin', () => {
       mappings: 'AAKA,QACE,oBAAc,AAAd,qBAAc,AAAd,iBAAc,AAAd,oBAAc,AAAd,YAAc,CACf,AAPD,cACE,GACE,UAAY,CACb,AAMD,GACE,UAAY,CACb,CAPF',
       file: 'sample.css'
     };
-    return plugin.compile({data, path: 'fixtures/sample.css'}).then(file => {
+    return plugin.optimize({data, path: 'fixtures/sample.css'}).then(file => {
       file.map.should.be.eql(map);
     });
   });


### PR DESCRIPTION
Fixes #18 (at least for me).

NOTE: If you want process regular .css files (not .scss or .less or whatever), don’t forget to install css-brunch.
