### PR TITLE
Add possibility to pass progeny options in plugin config

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ var style = require('./title.css');
 
 Note: enabling `modules` does so for every stylesheet in your project, so it's all-or-nothing. Even the files you don't require will be transformed into CSS modules (aka will have obfuscated class names, like turn `.title` into `._title_fdphn_1`).
 
+### Dependencies
+
+You can pass options for [progeny](https://github.com/es128/progeny) which retrieves dependencies for the input CSS file.
+
+For example, if you use [postcss-partial-import](https://github.com/jonathantneal/postcss-partial-import) plugin, your CSS files
+prefixed with underscore and have `.css` extension. In this case, you need pass to progeny `prefix` option, so brunch can
+properly rebuild your partials on their change.
+
+```javascript
+module.exports = {
+   // ...
+   plugins: {
+      postcss: {
+         progeny: {
+            prefix: '_'
+         }
+      }
+   }
+}
+```
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -46,7 +46,8 @@ class PostCSSCompiler {
 		this.map = this.config.map ?
 			Object.assign({}, defaultMapper, this.config.map) :
 			defaultMapper;
-		this.getDependencies = progeny({rootPath, reverseArgs: true});
+      const progenyOpts = Object.assign({}, {rootPath, reverseArgs: true}, cfg.progeny);
+		this.getDependencies = progeny(progenyOpts);
 		this.processor = postcss(proc);
 		this.modules = !!this.config.modules;
 	}

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class PostCSSCompiler {
 		this.map = this.config.map ?
 			Object.assign({}, defaultMapper, this.config.map) :
 			defaultMapper;
-      const progenyOpts = Object.assign({rootPath, reverseArgs: true}, cfg.progeny);
+		const progenyOpts = Object.assign({rootPath, reverseArgs: true}, cfg.progeny);
 		this.getDependencies = progeny(progenyOpts);
 		this.processor = postcss(proc);
 		this.modules = !!this.config.modules;

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class PostCSSCompiler {
 		this.map = this.config.map ?
 			Object.assign({}, defaultMapper, this.config.map) :
 			defaultMapper;
-      const progenyOpts = Object.assign({}, {rootPath, reverseArgs: true}, cfg.progeny);
+      const progenyOpts = Object.assign({rootPath, reverseArgs: true}, cfg.progeny);
 		this.getDependencies = progeny(progenyOpts);
 		this.processor = postcss(proc);
 		this.modules = !!this.config.modules;


### PR DESCRIPTION
Hi.

While using Brunch with PostCSS in my project I was disappointed with the bug that CSS partials were compiled but not saved to `app.css`. 

I'm using `postcss-partial-import` plugin which allows me to do sassy-like imports in plain css. e.g.:

``` css
@import "partial";
```

That partial file is located in the same directory and named `_partial.css`.

I have only one entry point - `app.css`. And everything is fine while I'm editing it. But when it comes to partials - brunch don't compile them. It is okay, because by default conventions it should not do that. But what if I need? 

PostCSS is very flexible system and it allows you to literally build your own CSS processor. So, I think, we need to add possibility to pass configuration to `progenu` which is used to determinate dependency tree of the CSS file.

**What do you think?**

P.S. The bug occured here because, by default, progenue uses default settings by file extension. In this case - `.css` files settings don't contain setting named `prefix` which breaks compilation scenario for me.
