### PR TITLE
Fix loading modules config

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ class PostCSSCompiler {
 			defaultMapper;
 		this.getDependencies = progeny({rootPath, reverseArgs: true});
 		this.processor = postcss(proc);
-		this.modules = !!this.config.modules;
+		this.modules = this.config.modules;
 	}
 
 	optimize(file) {


### PR DESCRIPTION
CSS module config options were getting eaten. Will only work once this is a compiler again.
