### PR TITLE
Revert removal of extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ class PostCSSCompiler {
 Object.assign(PostCSSCompiler.prototype, {
 	brunchPlugin: true,
 	type: 'stylesheet',
-	defaultEnv: '*',
+	extension: 'css',
 });
 
 module.exports = PostCSSCompiler;


### PR DESCRIPTION
The `extension` option was replaced with `defaultEnv` when this was temporarily switched to an optimizer.

CSS was not getting complied correctly until I added this back.
