### PR TITLE
prevent undefined fails the compiling

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,9 @@ class PostCSSCompiler {
 		const path = file.path;
 		const opts = {from: path, to: sysPath.basename(path), map: this.map};
 
+		if (file.data === undefined) {
+			file.data = '';
+		}
 		if (file.map) {
 			opts.map.prev = file.map.toJSON();
 		}

--- a/test.js
+++ b/test.js
@@ -81,4 +81,11 @@ describe('Plugin', () => {
     });
   });
 
+  it('compile when no data given', () => {
+    const expected = '';
+    return plugin.compile({path: 'a.css'}).then(actual => {
+      actual.data.should.eql(expected);
+    });
+  });
+
 });


### PR DESCRIPTION
When for some reason a css file is empty, `file.data` is `undefined` which will fail the compiling with error msg `Compiling of app/styles/something.css failed. Cannot read property 'toString' of undefined`.

This is somewhat confusing and produces an empty result will be less surprising.