### PR TITLE
Variables only files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,7 @@ class PostCSSCompiler {
 	}
 
 	compile(file) {
+		if(!file.data) return Promise.resolve();
 		const path = file.path;
 		const opts = {from: path, to: sysPath.basename(path), map: this.map};
 


### PR DESCRIPTION
Variables only files from LESS generates empty output that makes postcss crash.