### PR TITLE
".toJSON is not a function" when using sass-brunch with postcss-brunch

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,13 +73,13 @@ class PostCSSCompiler {
 			file.data = '';
 		}
 		if (file.map) {
-			opts.map.prev = file.map.toJSON();
+			opts.map.prev = JSON.stringify(file.map);
 		}
 
 		return this.processor.process(file.data, opts).then(result => {
 			notify(result.warnings());
 
-			const mapping = result.map.toJSON();
+			const mapping = JSON.stringify(result.map);
 			// Not sure why postcss gives the basename instead of the full path;
 			// TODO: investigate.
 			// For now, "the solution":


### PR DESCRIPTION
When using sass-brunch with postcss-brunch, I get the following error:
`error: Compiling of XXX.scss failed. TypeError: file.map.toJSON is not a function
  at PostCSSCompiler.compile (XXX/node_modules/postcss-brunch/index.js:59:29)`

After replacing the `toJSON` with the good old `JSON.stringify`, it worked like a charm.