### PR TITLE
Allow custom callback method for CSS modules getJSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,18 @@ const notify = (warnings) => {
 
 const cssModulify = (path, data, map, options) => {
 	let json = {};
-	const { getJSON = (_, _json)=> json = _json } = options;
 
-	return postcss([postcssModules(Object.assign({}, {getJSON}, options))])
+	const getJSON = (filename, _json)=> {
+		json = (
+			(
+				options.getJSON &&
+				options.getJSON(filename, _json)
+			) ||
+			_json
+		);
+	};
+
+	return postcss([postcssModules(Object.assign({}, options, {getJSON}))])
 		.process(data, {from: path, map}).then(x => {
 			const exports = 'module.exports = ' + JSON.stringify(json) + ';';
 			return { data: x.css, map: x.map, exports };

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const notify = (warnings) => {
 
 const cssModulify = (path, data, map, options) => {
 	let json = {};
-	const getJSON = (_, _json) => json = _json;
+	const { getJSON = (_, _json)=> json = _json } = options;
 
 	return postcss([postcssModules(Object.assign({}, {getJSON}, options))])
 		.process(data, {from: path, map}).then(x => {

--- a/package.json
+++ b/package.json
@@ -6,12 +6,7 @@
   "scripts": {
     "test": "mocha test"
   },
-  "keywords": [
-    "postcss",
-    "brunch",
-    "postprocessor",
-    "postcss-runner"
-  ],
+  "keywords": ["postcss", "brunch", "postprocessor", "postcss-runner"],
   "repository": {
     "type": "git",
     "url": "https://github.com/brunch/postcss-brunch.git"
@@ -31,6 +26,7 @@
     "mocha": "^3.0.0",
     "postcss-import": "^10.0.0",
     "postcss-scss": "^1.0.2",
-    "should": "^11.1.0"
+    "should": "^11.1.0",
+    "sinon": "^2.3.5"
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ const Plugin = require('./index');
 const fs = require('fs');
 const should = require('should');
 const Mocha = require('mocha');
+const sinon = require('sinon');
 
 describe('Tests', () => {
    const blankOpts = { reporter: function(){} }; // no output
@@ -114,6 +115,26 @@ describe('Plugin', () => {
 
     return scssPlugin.compile({data, path: 'fixtures/parser.scss'}).then(actual => {
       actual.data.should.be.equal(expected);
+    });
+  })
+
+  it('compile with custom getJSON method', ()=> {
+    const data = 'a{a:a}';
+    const customGetJSONCallback = sinon.stub().returns((_, json)=> json);
+
+    const moduleConfig = Object.assign(config, {
+      plugins: {
+        postcss:  Object.assign(config.plugins.postcss, {
+          modules: {
+            getJSON: customGetJSONCallback
+          }
+        })
+      }
+    });
+
+    return new Plugin(moduleConfig).compile({path: 'a.css', data})
+    .then(() => {
+      should(customGetJSONCallback.calledOnce).be.true();
     });
   })
 });

--- a/test.js
+++ b/test.js
@@ -132,8 +132,7 @@ describe('Plugin', () => {
       }
     });
 
-    return new Plugin(moduleConfig).compile({path: 'a.css', data})
-    .then(() => {
+    return new Plugin(moduleConfig).compile({path: 'a.css', data}).then(() => {
       should(customGetJSONCallback.calledOnce).be.true();
     });
   })


### PR DESCRIPTION
Currently implementing CSS Modules in Phoenix but need to be able to write the JSON to a _build directory without interfering with the Javascript imports.