### PR TITLE
Upgrade dependencies to PostCSS 6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,18 +19,18 @@
   "dependencies": {
     "anymatch": "^1.3.0",
     "loggy": "~0.3.5",
-    "postcss": "^5.0.0",
-    "postcss-modules": "^0.5.2",
+    "postcss": "^6.0.9",
+    "postcss-modules": "^0.8.0",
     "progeny": "^0.9.0"
   },
   "license": "MIT",
   "devDependencies": {
-    "autoprefixer": "^6.3.7",
-    "css-mqpacker": "^5.0.1",
-    "csswring": "^5.1.0",
+    "autoprefixer": "^7.1.2",
+    "css-mqpacker": "^6.0.1",
+    "csswring": "^6.0.0",
     "mocha": "^3.0.0",
-    "postcss-import": "^8.1.2",
-    "postcss-scss": "^0.4.1",
+    "postcss-import": "^10.0.0",
+    "postcss-scss": "^1.0.2",
     "should": "^11.1.0"
   }
 }


### PR DESCRIPTION
Upgrades all the dependencies that used postcss 5, to postcss 6. I read the changelogs of each dependency, and there seems to be nothing more to it, but I may be wrong (I just started using brunch).

This makes [postcss-nesting](https://github.com/jonathantneal/postcss-nesting) work again. Supposedly https://github.com/brunch/postcss-brunch/pull/46 should do the same, but I had some troubles with it.