### PR TITLE
Update Mocha and Loggy to address NPM audit "critical" warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "anymatch": "^1.3.0",
-    "loggy": "~0.3.5",
+    "loggy": "^1.0.2",
     "postcss": "^6.0.9",
     "postcss-modules": "^0.8.0",
     "progeny": "^0.9.0"
@@ -28,7 +28,7 @@
     "autoprefixer": "^7.1.2",
     "css-mqpacker": "^6.0.1",
     "csswring": "^6.0.0",
-    "mocha": "^3.0.0",
+    "mocha": "^5.2.0",
     "postcss-import": "^10.0.0",
     "postcss-scss": "^1.0.2",
     "should": "^11.1.0"


### PR DESCRIPTION
This change is primarily concerned with fixing:

1. https://nodesecurity.io/advisories/146.