### PR TITLE
Fix custom getJSON callback for CSS modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,22 @@ var style = require('./title.css');
 
 Note: enabling `modules` does so for every stylesheet in your project, so it's all-or-nothing. Even the files you don't require will be transformed into CSS modules (aka will have obfuscated class names, like turn `.title` into `._title_fdphn_1`).
 
+By default, a JSON file with exported classes will be placed next to corresponding CSS. But you have a freedom to make everything you want with exported classes, just use the `getJSON` callback:
+
+```javascript
+plugins: {
+  postcss: {
+    modules: {
+      getJSON: function(cssFileName, json, outputFileName) {
+        const path = require('path');
+        const jsonFileName  = path.resolve('./build/' + cssName + '.json');
+        fs.writeFileSync(cssFileName + ".json", JSON.stringify(json));
+      }
+    }
+  }
+}
+```
+
 ### Dependencies
 
 You can pass options for [progeny](https://github.com/es128/progeny) which retrieves dependencies for the input CSS file.
@@ -110,14 +126,14 @@ properly rebuild your partials on their change.
 
 ```javascript
 module.exports = {
-   // ...
-   plugins: {
-      postcss: {
-         progeny: {
-            prefix: '_'
-         }
+  // ...
+  plugins: {
+    postcss: {
+      progeny: {
+        prefix: '_'
       }
-   }
+    }
+  }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ const cssModulify = (path, data, map, options) => {
 		json = typeof options.getJSON === 'function' && options.getJSON(...args) || args[1]
 	};
 
-	return postcss([postcssModules(Object.assign({getJSON}, options))])
+	return postcss([postcssModules(Object.assign({}, options, {getJSON}))])
 		.process(data, {from: path, map}).then(x => {
 			const exports = 'module.exports = ' + JSON.stringify(json) + ';';
 			return { data: x.css, map: x.map, exports };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-brunch",
-  "version": "2.1.0",
+  "version": "2.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -23,7 +23,6 @@ describe('Tests', () => {
    });
 });
 
-
 describe('Plugin', () => {
   let plugin, config;
 
@@ -114,6 +113,28 @@ describe('Plugin', () => {
 
     return scssPlugin.compile({data, path: 'fixtures/parser.scss'}).then(actual => {
       actual.data.should.be.equal(expected);
+    });
+  })
+
+  it('compile with custom getJSON callback and exports json', () => {
+    const data = '.foo { color: red; }';
+    let isCalled = false;
+
+    const moduleConfig = Object.assign(config, {
+      plugins: {
+        postcss: Object.assign(config.plugins.postcss, {
+          modules: {
+            getJSON: (_, json) => {
+              isCalled = true;
+            }
+          }
+        })
+      }
+    });
+
+    return new Plugin(moduleConfig).compile({data, path: 'a.css'}).then(actual => {
+      isCalled.should.be.equal(true);
+      actual.exports.should.be.equal('module.exports = {"foo":"_foo_20tf4_1"};');
     });
   })
 });


### PR DESCRIPTION
In #56 the option to provide a custom `getJSON` callback for CSS modules was added.
But the order the options are merged seem to be wrong: when the callback is provided the original method is overwritten and the `json` variable is never set (always returns an empty object).
This was already suggested in [#45](https://github.com/brunch/postcss-brunch/pull/45/files#diff-168726dbe96b3ce427e7fedce31bb0bcR43), but didn't get merged.

**Todo:**

- [x] Fix custom getJSON callback for CSS modules
- [x] Create test
- [x] Update README
